### PR TITLE
Fix unsupported .NET callback format

### DIFF
--- a/HLHookNET4/src/Managed/HogwartsLegacyHook.cpp
+++ b/HLHookNET4/src/Managed/HogwartsLegacyHook.cpp
@@ -44,7 +44,7 @@ void HogwartsLegacy::Hook::GetPlayerPositionAndRotation(MFVector^% position, MFR
 	rotation->Roll = RelativeRotation.Roll;
 }
 
-void HogwartsLegacy::Hook::InitializeOverwolf(System::Action<System::Boolean>^ callback)
+void HogwartsLegacy::Hook::InitializeOverwolf(System::Action<System::Object^>^ callback)
 {
 	bool result = Initialize();
 	callback(result);

--- a/HLHookNET4/src/Managed/HogwartsLegacyHook.h
+++ b/HLHookNET4/src/Managed/HogwartsLegacyHook.h
@@ -21,7 +21,7 @@ namespace HogwartsLegacy {
 		bool Initialize();
 		void GetPlayerPositionAndRotation([System::Runtime::InteropServices::Out] MFVector^% position, [System::Runtime::InteropServices::Out] MFRotator^% rotation);
 
-		void InitializeOverwolf(System::Action<System::Boolean>^ callback);
+		void InitializeOverwolf(System::Action<System::Object^>^ callback);
 		void GetPlayerPositionAndRotationOverwolf(System::Action<System::Object^, System::Object^>^ callback);
 	};
 }


### PR DESCRIPTION
Overwof can only handle `object` as callback format.

``` 
Error: Failed to execute InitializeOverwolf on Hook with 1 arguments. details: argument '0' error: unsupported .NET callback format. only the following callback are supported: Action<object>, Action<objectobject>, Action<object, object, object> 
```
